### PR TITLE
fix: 이미지 및 컨테이너 이름을 소문자로 변경

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,8 +8,9 @@ USER=keeper
 
 for PROBLEM in ${NC_PROBLEMS[@]}
 do
-	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM} -f Dockerfile.nc .
-	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM &
+    PROBLEM_LOWER=$(echo $PROBLEM | tr '[:upper:]' '[:lower:]')
+	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM_LOWER} -f Dockerfile.nc .
+	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM_LOWER_LOWER &
 
 	let PORT=${PORT}+1
 done
@@ -20,8 +21,9 @@ PYTHON_PROBLEMS=("basic_zkp")
 
 for PROBLEM in ${PYTHON_PROBLEMS[@]}
 do
-	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM} -f Dockerfile.python .
-	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM &
+    PROBLEM_LOWER=$(echo $PROBLEM | tr '[:upper:]' '[:lower:]')
+	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM_LOWER} -f Dockerfile.python .
+	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM_LOWER &
 
 	let PORT=${PORT}+1
 
@@ -33,8 +35,9 @@ FLASK_PROBLEMS=("goback")
 
 for PROBLEM in ${FLASK_PROBLEMS[@]}
 do
-	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM} -f Dockerfile.flask .
-	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM &
+    PROBLEM_LOWER=$(echo $PROBLEM | tr '[:upper:]' '[:lower:]')
+	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM_LOWER} -f Dockerfile.flask .
+	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM_LOWER &
 
 	let PORT=${PORT}+1
 
@@ -46,8 +49,9 @@ PHP_PROBLEMS=("keeper_bird" "obfuscation" "shop" "lord")
 
 for PROBLEM in ${PHP_PROBLEMS[@]}
 do
-	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM} -f Dockerfile.php .
-	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM &
+    PROBLEM_LOWER=$(echo $PROBLEM | tr '[:upper:]' '[:lower:]')
+	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM_LOWER} -f Dockerfile.php .
+	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM_LOWER &
 
 	let PORT=${PORT}+1
 
@@ -59,9 +63,10 @@ OTHER_PROBLEMS=("xmlparser" "lighttpd")
 
 for PROBLEM in ${OTHER_PROBLEMS[@]}
 do
+    PROBLEM_LOWER=$(echo $PROBLEM | tr '[:upper:]' '[:lower:]')
 	cd ./problem/$PROBLEM
-	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM} -f Dockerfile .
-	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM &
+	docker build --build-arg PROBLEM=${PROBLEM} --build-arg PORT=${PORT} --build-arg USER=${USER} -t ${PROBLEM_LOWER} -f Dockerfile .
+	docker run --name $PROBLEM -p $PORT:$PORT -i $PROBLEM_LOWER &
 
 	let PORT=${PORT}+1
 	cd ../..


### PR DESCRIPTION
문제 이름에 대문자가 포함될 경우 아래 오류가 발생해서 이미지랑 컨테이너 이름은 소문자로 변경하도록 했습니다.

```
// docker build
for "-t, --tag" flag: invalid reference format: repository name must be lowercase
// docker run
docker: invalid reference format: repository name must be lowercase.
```